### PR TITLE
Change the image family and add the bucket location to fix the lab

### DIFF
--- a/fw_common.tf
+++ b/fw_common.tf
@@ -6,6 +6,7 @@ module "bootstrap_common" {
   file_location = "bootstrap_files/"
   config        = ["init-cfg.txt", "bootstrap.xml"]
   license       = ["authcodes"]
+  bucket_location = var.regions[0]
 }
 
 #-----------------------------------------------------------------------------------------------

--- a/modules/gcp_bootstrap/main.tf
+++ b/modules/gcp_bootstrap/main.tf
@@ -11,6 +11,7 @@ resource "random_string" "randomstring" {
 resource "google_storage_bucket" "bootstrap" {
   name          = local.bucket_name
   force_destroy = true
+  location = var.bucket_location
 }
 
 resource "google_storage_bucket_object" "config_full" {

--- a/modules/gcp_bootstrap/variables.tf
+++ b/modules/gcp_bootstrap/variables.tf
@@ -1,6 +1,9 @@
 variable bucket_name {
 }
 
+variable bucket_location{
+}
+
 variable file_location {
 }
 

--- a/spokes.tf
+++ b/spokes.tf
@@ -19,7 +19,7 @@ module "vm_spoke1" {
   ]
   subnetworks           = [module.vpc_spoke1.subnetwork_self_link[0]]
   machine_type          = "f1-micro"
-  image                 = "ubuntu-os-cloud/ubuntu-1604-lts"
+  image                 = "ubuntu-os-cloud/ubuntu-1804-lts"
   create_instance_group = true
   ssh_key               = fileexists(var.public_key_path) ? "${var.spoke_user}:${file(var.public_key_path)}" : ""
   startup_script        = file("${path.module}/scripts/webserver-startup.sh")
@@ -86,7 +86,7 @@ module "vm_spoke2" {
   names        = var.spoke2_vms
   zones        = [data.google_compute_zones.available.names[0]]
   machine_type = "f1-micro"
-  image        = "ubuntu-os-cloud/ubuntu-1604-lts"
+  image        = "ubuntu-os-cloud/ubuntu-1804-lts"
   subnetworks  = [module.vpc_spoke2.subnetwork_self_link[0]]
   ssh_key      = fileexists(var.public_key_path) ? "${var.spoke_user}:${file(var.public_key_path)}" : ""
 }


### PR DESCRIPTION
## Description

- Change the VM image family from ubuntu-1604-lts which is not present in GCP anymore to the working ubuntu-1804-lts
- Add the required **location** field to the bootstrap GCS bucket config, otherwise it doesn't deploy at all

## Motivation and Context

I had to fix it during the lab I've just taken on Qwiklabs, without these changes Terraform failed to apply the configuration.

## How Has This Been Tested?

I've used this code in the [Qwiklabs](https://www.qwiklabs.com/focuses/10946?parent=catalog) Lab successfully.



## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
Not required as none of this behaviour is covered in the documentation
- [ ] I have read the **CONTRIBUTING** document.
There is no **CONTRIBUTING** document in this repository.
- [ ] I have added tests to cover my changes if appropriate.
There are no tests in this repository.
- [ ] All new and existing tests passed.
No tests means nothing has to pass :)
